### PR TITLE
Add missing closing brace to TransactionAdapter

### DIFF
--- a/Blockexplorer.BlockProvider.Rpc/TransactionAdapter.cs
+++ b/Blockexplorer.BlockProvider.Rpc/TransactionAdapter.cs
@@ -96,46 +96,33 @@ namespace Blockexplorer.BlockProvider.Rpc
 					Index = index++
 				};
 
-				if (output.ScriptPubKey.Addresses != null) // Satoshi 14.2
-					@out.Address = output.ScriptPubKey.Addresses.FirstOrDefault();
-				else
-				{
-					string hexScript = output.ScriptPubKey.Hex;
-
-					if (!string.IsNullOrEmpty(hexScript))
-					{
-						byte[] decodedScript = Encoders.Hex.DecodeData(hexScript);
-						Script script = new Script(decodedScript);
-						var pubKey = PayToPubkeyTemplate.Instance.ExtractScriptPubKeyParameters(script);
-						if (pubKey != null)
-						{
-							BitcoinPubKeyAddress address = pubKey.GetAddress(NetworkSpec.ObsidianMain());
-							@out.Address = address.ToString();
-						}
-						else
-						{
-							@out.Address = script.ToString();
-						}
-						
-					}
-					else
-					{
-						@out.Address = "none";
-					}
-/*
-
                 if (output.ScriptPubKey.Addresses != null) // Satoshi 14.2
                     @out.Address = output.ScriptPubKey.Addresses.FirstOrDefault();
                 else
                 {
                     string hexScript = output.ScriptPubKey.Hex;
-					byte[] decodedScript = Encoders.Hex.DecodeData(hexScript);
-					Script script = new Script(decodedScript);
-					var pubKey = PayToPubkeyTemplate.Instance.ExtractScriptPubKeyParameters(script);
-					BitcoinPubKeyAddress address = pubKey.GetAddress(NetworkSpec.ObsidianMain());
-					@out.Address = address.ToString();
-				}
-*/
+
+                    if (!string.IsNullOrEmpty(hexScript))
+                    {
+                        byte[] decodedScript = Encoders.Hex.DecodeData(hexScript);
+                        Script script = new Script(decodedScript);
+                        var pubKey = PayToPubkeyTemplate.Instance.ExtractScriptPubKeyParameters(script);
+                        if (pubKey != null)
+                        {
+                            BitcoinPubKeyAddress address = pubKey.GetAddress(NetworkSpec.ObsidianMain());
+                            @out.Address = address.ToString();
+                        }
+                        else
+                        {
+                            @out.Address = script.ToString();
+                        }
+
+                    }
+                    else
+                    {
+                        @out.Address = "none";
+                    }
+                }
 				transaction.TransactionsOut.Add(@out);
 			}
 


### PR DESCRIPTION
`Blockexplorer.BlockProvider.Rpc.TransactionAdapter` appears to have a missing closing brace just before `transaction.TransactionsOut.Add(@out);` around line 139. I think this was introduced by this commit:

https://github.com/obsidianproject/Blockexplorer/commit/5071831778742a97c5bf48a2751fa085e4762075#diff-fbe8906b259a8681f0525ef469061a93