### PR TITLE
Fix GetStakingInfo deserialization

### DIFF
--- a/Blockexplorer.BlockProvider.Rpc/Client/BitcoinRpcClient.cs
+++ b/Blockexplorer.BlockProvider.Rpc/Client/BitcoinRpcClient.cs
@@ -146,8 +146,8 @@ namespace Blockexplorer.BlockProvider.Rpc.Client
 		public async Task<GetStakingInfoRpcModel> GetStakingInfo()
 		{
 			var json = await InvokeMethod("getstakinginfo");
-			var result = JsonConvert.DeserializeObject<GetStakingInfoRpcModel>(json);
-			return result;
+			var result = JsonConvert.DeserializeObject<TransportRpcModel<GetStakingInfoRpcModel>>(json);
+			return result.Result;
 		}
 	}
 

--- a/Blockexplorer.BlockProvider.Rpc/Client/GetStakingInfoRpcModel.cs
+++ b/Blockexplorer.BlockProvider.Rpc/Client/GetStakingInfoRpcModel.cs
@@ -4,28 +4,37 @@ namespace Blockexplorer.BlockProvider.Rpc.Client
 {
     public class GetStakingInfoRpcModel
     {
-            [JsonProperty("currentblocksize")]
-            public int CurrentBlockSize { get; set; }
+        [JsonProperty("enabled")]
+        public bool Enabled { get; set; }
 
-            [JsonProperty("currentblocktx")]
-            public int CurrentBlockTx { get; set; }
+        [JsonProperty("staking")]
+        public bool Staking { get; set; }
 
-            [JsonProperty("pooledtx")]
-            public int PooledTx { get; set; }
+        [JsonProperty("errors")]
+        public string Errors { get; set; }
 
-            [JsonProperty("difficulty")]
-            public decimal Difficulty { get; set; }
+        [JsonProperty("currentblocksize")]
+        public int CurrentBlockSize { get; set; }
 
-            [JsonProperty("search-interval")]
-            public int SearchInterval { get; set; }
+        [JsonProperty("currentblocktx")]
+        public int CurrentBlockTx { get; set; }
 
-            [JsonProperty("weight")]
-            public int Weight { get; set; }
+        [JsonProperty("pooledtx")]
+        public int PooledTx { get; set; }
 
-            [JsonProperty("netstakeweight")]
-            public int NetStakeWeight { get; set; }
+        [JsonProperty("difficulty")]
+        public double Difficulty { get; set; }
 
-            [JsonProperty("expectedtime")]
-            public int ExpectedTime { get; set; }
+        [JsonProperty("search-interval")]
+        public int SearchInterval { get; set; }
+
+        [JsonProperty("weight")]
+        public long Weight { get; set; }
+
+        [JsonProperty("netstakeweight")]
+        public long NetStakeWeight { get; set; }
+
+        [JsonProperty("expectedtime")]
+        public int ExpectedTime { get; set; }
     }
 }

--- a/Blockexplorer.Core/Domain/StakingInfo.cs
+++ b/Blockexplorer.Core/Domain/StakingInfo.cs
@@ -9,10 +9,10 @@ namespace Blockexplorer.Core.Domain
         public int CurrentBlockSize { get; set; }
         public int CurrentBlockTx { get; set; }
         public int PooledTx { get; set; }
-        public decimal Difficulty { get; set; }
+        public double Difficulty { get; set; }
         public int SearchInterval { get; set; }
-        public int NetStakeWeight { get; set; }
-        public int Weight { get; set; }
+        public long NetStakeWeight { get; set; }
+        public long Weight { get; set; }
         public int ExpectedTime { get; set; }
     }
 }


### PR DESCRIPTION
Fixes #15 

**Problem:** StakingInfo results from the Rpc are failing to deserialize causing the `StakingInfoAdapter` to return default values.

**Resolution:** Changed datatypes in the StakingInfo model to correspond with the datatypes in the Rpc's Json result. The deserialization object type was also changed from `GetStakingInfoRpcModel` to `TransportRpcModel<GetStakingInfoRpcModel>`